### PR TITLE
Refactor to expose savePixels

### DIFF
--- a/src/ofxTinyEXR.cpp
+++ b/src/ofxTinyEXR.cpp
@@ -335,15 +335,15 @@ bool ofxTinyEXR::loadImage(ofFloatImage & image, const string filepath){
  }
  */
 
-bool ofxTinyEXR::saveImage( const ofFloatImage & img, string filepath){
+bool ofxTinyEXR::savePixels( const ofFloatPixels & pixels, string filepath){
     
     string filepath_full =ofToDataPath(filepath);
     const char * filename = filepath_full.c_str();
     
-    const float * data = img.getPixels().getData();
-    int width = img.getPixels().getWidth();
-    int height = img.getPixels().getHeight();
-    int components = img.getPixels().getNumChannels();
+    const float * data = pixels.getData();
+    int width = pixels.getWidth();
+    int height = pixels.getHeight();
+    int components = pixels.getNumChannels();
     int save_as_fp16 = 0; // save as float, not half
     
     const char* err = NULL; // or nullptr in C++11
@@ -359,6 +359,10 @@ bool ofxTinyEXR::saveImage( const ofFloatImage & img, string filepath){
     }
     
     return true;
+}
+
+bool ofxTinyEXR::saveImage( const ofFloatImage & img, string filepath){
+  return savePixels(img.getPixels(), filepath);
 }
 
 bool ofxTinyEXR::saveHDRImage( const ofFloatImage & img, string filepath){


### PR DESCRIPTION
This minor refactor allows pixels to be fetched from a GPU FBO, then to save those pixels as an EXR file on the CPU without roundtripping through an ofFloatImage, which depends on OpenGL. Which means that the slow "save to disk" process can happen on a worker thread once the pixels have been fetched.